### PR TITLE
Run prettier on all relevant files

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,10 +47,10 @@
         "node ./scripts/lint-staged/tslint",
         "git add"
       ],
-      "*.js": [
-        "node ./scripts/lint-staged/prettier",
-        "git add"
-      ]
+      "*.{js,jsx,json,scss,html,md,yml}": [
+        "node ./scripts/lint-staged/prettier",
+        "git add"
+      ]
     },
     "ignore": [
       "common/scripts/*.js",


### PR DESCRIPTION
Rather than running prettier on only ts/tsx/js on precommit, we should run it on all file types the extension handles. This will reduce discrepancies introduced by the combination of `"editor.formatOnSave": true` and non-Prettier formatters.